### PR TITLE
Clean up and fix various issues in Resources

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,9 @@ plugins:
   - jemoji
   - jekyll-github-metadata
 
+relative_links:
+  enabled:     true
+  collections: true
 
 collections:
   seminars:

--- a/_resources/Description.md
+++ b/_resources/Description.md
@@ -1,6 +1,6 @@
 ---
-title: Description
-order: 2
+title: Course Description
+order: 1
 ---
 
 # UMM CSci Senior Seminar description and requirements

--- a/_resources/Description.md
+++ b/_resources/Description.md
@@ -23,7 +23,7 @@ One of the few really consistent themes we get from alumni and employers is the 
 {:toc}
 
 
-### Course goals and learning objectives
+## Course goals and learning objectives
 There are three major goals:
 - Learn to read, understand, and synthesize research literature in the field.
 - Write a high quality paper synthesizing and presenting summaries of computing research literature.
@@ -33,7 +33,7 @@ Other goals implied by these include:
 - Gain additional confidence and experience in both writing and speaking.
 - Gain increased facility in the critical and careful use of tools used to generate high quality articles and presentation materials.
 
-### Requirements
+## Requirements
 In the course of a semester a student writes a 5-6 page paper (ACM style, see sample papers and resources) that is an overview of recent peer-reviewed computer science publications on a topic of their choice. The student presents the paper as a 25 minute conference-style presentation for faculty, fellow students, alumni, and others. The student needs to demonstrate in-depth understanding of their topic by writing a clear paper that summarizes (in the students' own words) the material that they learned from their sources and clearly presenting it, including the ability to answer questions on the material. Specifically:
 
 - The target audience for the paper and presentation are computer science students who have just finished Data Structures. Any terminology and background used in the paper that such students are not expected to have needs to be clearly explained.
@@ -44,20 +44,20 @@ In the course of a semester a student writes a 5-6 page paper (ACM style, see sa
 
 The student is expected to work with their advisor and the course instructor on making progress towards the final paper/presentation, to be proactive in sorting out potential issues, and to take into account feedback from their advisor, course instructor, and paper reviewers (alumni and fellow students).
 
-### Senior Seminar Instructor
+## Senior Seminar Instructor
 The course instructor conducts in-class meetings, provides feedback on students' submitted work, keeps track of students' milestones (see the cookie system), and takes care of organizational issues (printing the proceedings, room reservations, etc). The instructor is also there to answer questions and to (try to) resolve whatever issues might come up. If issues arise in the course, please contact the instructor as soon as possible (in person or by email) to resolve the problem.
 
-### Senior Seminar Advisor
+## Senior Seminar Advisor
 Each student works with a faculty advisor on a chosen topic. Your advisor is one of Csci faculty (including the course instructor). In the beginning of the semester students pick a general area for a Seminar topic and approach a potential advisor based on a match in the topic of interest. We usually try to balance Senior Seminar advising loads among faculty so if you would like to work with a particular person, talk to them early so that they are still available. However, even if the topic match is not perfect, your advisor is still a highly valuable resource.
 
 Usually you meet with your advisor once a week and submit all of your intermediate work (bibliography, drafts, etc) to them, in addition to the course instructor. Your advisor gives you feedback on intermediate drafts and helps you in all aspects of the course, from narrowing down a topic and literature search to practice presentations. Your advisor is the first source of help when you are stuck or have a question. Meeting with your advisor regularly and seeking their help as soon as an issue arises is essential for the success in the course.
 
-### Texts and other materials
+## Texts and other materials
 Your key source of materials will be research literature in the field. We'll talk about how to find things in class, and your advisor can be a big help there as well. There are also some useful links on the [resources page](seniorsemresources.md).
 
 We will also be reading a textbook on writing in computer science - it has plenty of helpful advice, so please read it carefully and revisit it often as you are working on your papers. 
 
-### Course work and grading
+## Course work and grading
 Grades in CSci 4901 are determined by the CSci faculty as a whole after the final papers are submitted. Grades will be based on the following:
 
 - Your technical paper

--- a/_resources/Description.md
+++ b/_resources/Description.md
@@ -3,10 +3,7 @@ title: Description
 order: 2
 ---
 
-# UMM CSci senior seminar description and requirements
-{:.no_toc}
-
-## Description.
+# UMM CSci Senior Seminar description and requirements
 {:.no_toc}
 
 This is the senior seminar (CSci 4901) description in the catalog: 

--- a/_resources/Description.md
+++ b/_resources/Description.md
@@ -56,7 +56,7 @@ Each student works with a faculty advisor on a chosen topic. Your advisor is one
 Usually you meet with your advisor once a week and submit all of your intermediate work (bibliography, drafts, etc) to them, in addition to the course instructor. Your advisor gives you feedback on intermediate drafts and helps you in all aspects of the course, from narrowing down a topic and literature search to practice presentations. Your advisor is the first source of help when you are stuck or have a question. Meeting with your advisor regularly and seeking their help as soon as an issue arises is essential for the success in the course.
 
 ### Texts and other materials
-Your key source of materials will be research literature in the field. We'll talk about how to find things in class, and your advisor can be a big help there as well. There are also some useful links on the [resources page](https://umm-csci.github.io/senior-seminar/resources/seniorsemresources.html).
+Your key source of materials will be research literature in the field. We'll talk about how to find things in class, and your advisor can be a big help there as well. There are also some useful links on the [resources page](seniorsemresources.md).
 
 We will also be reading a textbook on writing in computer science - it has plenty of helpful advice, so please read it carefully and revisit it often as you are working on your papers. 
 
@@ -74,7 +74,7 @@ Grades in CSci 4901 are determined by the CSci faculty as a whole after the fina
 The above items are all important, in slightly different contexts, for almost any career you may choose.
 
 
-Additionally check out [Cookie System](https://umm-csci.github.io/senior-seminar/resources/cookieResources.html) for important grading information.
+Additionally check out [Cookie System](cookieResources.html) for important grading information.
 
 The CSci faculty may choose to acknowledge certain papers or presentations as deserving a distinction (informally known as *Gold Star*) as an indication of their unusually high quality. Getting a gold star corresponds to passing senor seminar with distinction. While this is not formally reflected in the grade, it's a great thing to put on your resume or grad school application.
 

--- a/_resources/Examplesofgoodwriting.md
+++ b/_resources/Examplesofgoodwriting.md
@@ -3,13 +3,13 @@ title: Examples of good writing
 ---
 
 # Examples of good writing
+{:.no_toc}
 
 There are lots of great papers out there, but they are typically surrounded by vast oceans of poop (much like almost every other cultural artifact). Here are some examples, but this is by no means meant to be a complete or exclusive list, and we'd love it if people would add examples to this list. It is currently focused on papers; we could expand this to include books and other forms of writing, but it seems that traditional papers would be the most useful as examples for Senior Seminar. 
 
-- [Genetic Programming for Finite Algebras](#genetic-programming-for-finite-algebras)
-- [GP-Gammon: Using Genetic Programming to Evolve Backgammon Players](#backgammon)   
-- [Go To Statement Considered Harmful](#go-to-statement-considered-harmful)
-- [Abstraction mechanisms in CLU](#abstraction-mechanisms-in-clu)
+* Do not remove this line (it will not be displayed)
+{:toc}
+
 
 ### Genetic Programming for Finite Algebras
 
@@ -19,7 +19,7 @@ still quite readable.
 
 [http://hampshire.edu/lspector/gpfa-gecco-2008/](http://hampshire.edu/lspector/gpfa-gecco-2008/)
 
-### <a name="backgammon"></a>GP-Gammon: Using Genetic Programming to Evolve Backgammon Players
+### GP-Gammon: Using Genetic Programming to Evolve Backgammon Players
 
 This also won a Human Competitive Result prize. It's worth noting that Lee Spector (first author on the Finite Algebras paper) 
 and Moshe Sipper (first author on this paper) have been consistently competitive for these sorts of awards over the years.

--- a/_resources/Examplesofgoodwriting.md
+++ b/_resources/Examplesofgoodwriting.md
@@ -1,8 +1,9 @@
 ---
-title: Examples of good writing
+title: Examples of Good Writing
+order: 9
 ---
 
-# Examples of good writing
+# Examples of Good Writing
 {:.no_toc}
 
 There are lots of great papers out there, but they are typically surrounded by vast oceans of poop (much like almost every other cultural artifact). Here are some examples, but this is by no means meant to be a complete or exclusive list, and we'd love it if people would add examples to this list. It is currently focused on papers; we could expand this to include books and other forms of writing, but it seems that traditional papers would be the most useful as examples for Senior Seminar. 

--- a/_resources/FindingSources.md
+++ b/_resources/FindingSources.md
@@ -1,5 +1,6 @@
 ---
-title: Finding sources for your senior seminar paper
+title: Finding Sources
+order: 6
 ---
 
 # Finding sources for your senior seminar paper

--- a/_resources/FindingSources.md
+++ b/_resources/FindingSources.md
@@ -3,38 +3,43 @@ title: Finding sources for your senior seminar paper
 ---
 
 # Finding sources for your senior seminar paper
+{:.no_toc}
 
 Your paper will be based on recent peer reviewed computer science research literature. We require you to have at least three reasonably recent peer reviewed sources as key sources of your paper. 
 
 It is essential that you use sources that inform you about the topic of your paper in a way that you can understand and summarize in your paper and your presentation. The topic of your paper is ultimately determined by your sources. If the source papers that you are trying to use are too complex or not detailed enough or poorly written, writing your own paper based on these sources would be very challenging and may be frustrating. Thus, choosing good sources at an appropriate level is one of the keys to writing a good senior seminar paper. 
 
-## Finding sources
-
-*Peer reviewed* computer science literature means papers that were published in computer science journals or proceedings of computer science conferences or workshops where publications are selected based on reviews by experts in the field. This writeup explains peer review process: [Meet Science: What is "peer review"?](http://boingboing.net/2011/04/22/meet-science-what-is.html) 
+* Do not remove this line (it will not be displayed)
+{:toc} 
 
 ## Guidelines for sources for your paper
 
 While the general requirement is to have at least three fairly recent published peer-reviewed sources, the specifics of these requirements depend on your topic: 
 
-**Recent sources** For an active area and a sufficiently general topic (e.g. machine learning or network security) we would expect that all your primary sources are published within the last 3-4 years. If your topic is more specific and/or slower developing (e.g. applications of machine learning to medical records or assistive technology for middle school teachers), you might not be able to find all sources within the last 3-4 years. In this case it's ok to have one recent source (within 3-4 years) and the other two be somewhat older. 
-<br />
+### Recent sources
+For an active area and a sufficiently general topic (e.g. machine learning or network security) we would expect that all your primary sources are published within the last 3-4 years. If your topic is more specific and/or slower developing (e.g. applications of machine learning to medical records or assistive technology for middle school teachers), you might not be able to find all sources within the last 3-4 years. In this case it's ok to have one recent source (within 3-4 years) and the other two be somewhat older. 
+
 It is up a responsibility of the student to search for sources and to discuss with their adviser and the senior seminar instructor what is available. If no new sources are available, but the topic is interesting, we may suggest widening the topic or we may be ok with the student using somewhat older sources.
 
 Some senior seminar papers are survey papers and cover more than three sources. For instance, see [Concurrent Compaction in JVM Garbage Collection by Jacob Opdahl](../seminars/fall2015/Opdahl.pdf) ([Fall 2015](../seminars/fall2015)).
 
 We also want to make sure that you are presenting a reasonably complete picture of the state of the art in a specific area. Thus your three primary sources shouldn't all come from the same author or group of authors. 
 
-**Primary vs supplementary sources**
+### Primary vs supplementary sources
 Primary sources are the ones that provide information for the core of your paper. Your paper needs to clearly explain the methods and the results presented in your primary sources in a way that's understandable to students at the Data Structures level. 
 
 In order to better understand methods used in your paper you are likely to use supplementary sources: papers that the primary sources are building upon, textbooks, technical reports, wikipedia articles, talks and blog posts by researchers explaining the concepts, etc. Some of these materials may be peer reviewed, and some wouldn't be. Make sure they are trustworthy. You need to cite them in your paper (we discuss proper citing later). 
 
-**Using your sources**
+### Using your sources
 Typically your primary sources cover the same topic from different angles. Some example of senior seminar papers that follow this approach: [Image Resizing using Seam Carving by Kristin Rachor](../seminars/fall2015/Rachor.pdf) ([Fall 2015](../seminars/fall2015)), [Monte Carlo Tree Search and Its Applications by Max Magnuson](../seminars/spring2015/Magnuson.pdf) ([Spring 2015](../seminars/spring2015)).  
 
 However, sometimes it makes sense to focus on one main source and background information for it, and spend less time on applications of the methods: [Parallel BVH Construction for Real-Time Ray Tracing by Aaron Lemmon](../seminars/spring2016/lemmon.pdf) ([Spring 2016](../seminars/spring2016)).  
 
-Make sure to discuss your paper structure with your adviser and the instructor to figure out what works best for your topic. 
+Make sure to discuss your paper structure with your adviser and the instructor to figure out what works best for your topic.
+ 
+## Finding sources
+
+*Peer reviewed* computer science literature means papers that were published in computer science journals or proceedings of computer science conferences or workshops where publications are selected based on reviews by experts in the field. This writeup explains peer review process: [Meet Science: What is "peer review"?](http://boingboing.net/2011/04/22/meet-science-what-is.html)
 
 ### Sources from journals, conferences, and workshops
 

--- a/_resources/Goldstardistinction.md
+++ b/_resources/Goldstardistinction.md
@@ -1,10 +1,11 @@
 ---
-title: Gold star distinction 
+title: Gold Star Distinction 
+order: 5
 ---
 
-# Gold star distinction &#x2B50;
+# Gold Star Distinction &#x2B50;
 
-As you know, senior seminar is graded pass/fail. However, starting Fall 2011 we note excellent papers and presentations as "passed with distinction". Those would be marked with a "gold star" on the wiki and be recommended to future students as examples of what we are looking for. If you receive a distinction on your paper or presentation, make sure to note it on your resume. Congratulations to those who received this distinction!
+As you know, senior seminar is graded pass/fail. However, starting Fall 2011 we note excellent papers and presentations as "passed with distinction". Those would be marked with a "gold star" (&#x2B50;) on the website and be recommended to future students as examples of what we are looking for. If you receive a distinction on your paper or presentation, make sure to note it on your resume. Congratulations to those who received this distinction!
 
 See each semester's papers and talks [here](https://umm-csci.github.io/senior-seminar/seminars/) for gold star papers and presentation slide decks.
 

--- a/_resources/Keypointsandpaperoutlines.md
+++ b/_resources/Keypointsandpaperoutlines.md
@@ -6,7 +6,7 @@ title: Key points and paper outlines
 
 We have consistently found that often students don't see the "big picture" of their paper and don't have a good understanding of the sources' contributions up until preparing their presentation at the end of the semester. This intermediate deadline is designed to help students get a better understanding of their work earlier in the semester.
 
-### Key points of your paper
+## Key points of your paper
 
 Academic papers tend to contribute at least one new thing to further work in an area, and the authors usually describe 
 their contributions by situating their work compared to other (previous) work in the area. 
@@ -26,7 +26,7 @@ Some items may not apply directly to papers in all areas. If that's the case wit
 
 If you have any questions, please talk to the instructor and/or your advisor.
 
-### Outline of your paper
+## Outline of your paper
 
 The outline of your paper describes the structure of your paper. This should include at least sections and subsections, along with a brief (one sentence) description of each. You should also mention the key sources you'll use for each section/subsection. You may want to expand the outline out to the level of paragraphs (or parts of subsections); this is particularly useful for areas that you're uncertain about or which you think will be challenging.
 

--- a/_resources/Keypointsandpaperoutlines.md
+++ b/_resources/Keypointsandpaperoutlines.md
@@ -1,8 +1,9 @@
 ---
-title: Key points and paper outlines
+title: Key Points and Paper Outlines
+order: 7
 ---
 
-# Key points and paper outlines
+# Key Points and Paper Outlines
 
 We have consistently found that often students don't see the "big picture" of their paper and don't have a good understanding of the sources' contributions up until preparing their presentation at the end of the semester. This intermediate deadline is designed to help students get a better understanding of their work earlier in the semester.
 

--- a/_resources/LatexformatingFAQ.md
+++ b/_resources/LatexformatingFAQ.md
@@ -1,5 +1,6 @@
 ---
-title: LaTeX formatting FAQ
+title: LaTeX Formatting FAQ
+order: 10
 ---
 
 # FAQ on LaTeX formatting for UMM CSci senior seminar

--- a/_resources/LatexformatingFAQ.md
+++ b/_resources/LatexformatingFAQ.md
@@ -3,25 +3,20 @@ title: LaTeX formatting FAQ
 ---
 
 # FAQ on LaTeX formatting for UMM CSci senior seminar
+{:.no_toc}
 
 Feel free to add questions and answers and improve the current answers. 
 
-- [A $ in my verbatim breaks TexMaker](#dollar)
-- [How do I format a url in a paper?](#url)
-- [How do I add a url to a bibliography item?](#bib)
-- [How do I balance the last two columns if \balancecolumns has no effect?](#balance)
-- [How do I check if my paper uses A4 or Letter Paper?](#a4)
-- [How do change my page size from A4 to Letter Paper?](#a4change)
-- [How do I preserve capitalization in titles in my bibliography?](#capital)
-- [How do I get rid of the navigation icons in Beamer?](#nav_icons)
+* Do not remove this line (it will not be displayed)
+{:toc}
 
-#### <a name="dollar"><a/>A $ in my verbatim breaks TexMaker
+### A `$` in my verbatim breaks TexMaker
 
-Add a %$ at the end of your verbatim environment.
+Add a `%$` at the end of your verbatim environment.
 
-#### <a name="url"></a>How do I format a url in a paper?
+### How do I format a url in a paper?
 
-Include a url package in the beginning of the paper (before \begin{document}):
+Include a url package in the beginning of the paper (before `\begin{document}`):
 
 ```latex
  \usepackage{url} 
@@ -29,8 +24,8 @@ Include a url package in the beginning of the paper (before \begin{document}):
 
  Then use `\url{...}` for urls.
 
-#### <a name="bib"></a>How do I add a url to a bibliography item?
-If you are referencing an online article, use the following in your .bib file:
+### How do I add a url to a bibliography item?
+If you are referencing an online article, use the following in your `.bib` file:
 
 ```latex
 @misc{...,
@@ -39,9 +34,9 @@ If you are referencing an online article, use the following in your .bib file:
 } 
 ```
 
-[Here](http://www.tex.ac.uk/FAQ-citeURL.html) is more information (caution: you must use ACM bibliography style so suggestions to change the style aren't applicable).
+[Here](https://texfaq.org/FAQ-citeURL.html) is more information (caution: you must use ACM bibliography style so suggestions to change the style aren't applicable).
 
-#### <a name="balance"></a>How do I balance the last two columns if \balancecolumns has no effect?
+### How do I balance the last two columns if `\balancecolumns` has no effect?
 
 ```latex
 \usepackage{balance}
@@ -51,15 +46,16 @@ If you are referencing an online article, use the following in your .bib file:
 \end{document} 
 ```
 
-[Here](http://ctan.mackichan.com/macros/latex/contrib/preprint/balance.pdf) is more information.
+[Here](https://ctan.org/pkg/balance?lang=en) is more information.
 
-#### <a name="a4"></a>How do I check if my paper uses A4 or Letter Paper?
+### How do I check if my paper uses A4 or Letter Paper?
 Using the templates from the senior seminar github fixes this issue Open it in Adobe Reader, go to File menu, and select Properties. In the tab Description it should show Paper Size as 8.5in by 11in (letter paper size). Otherwise it's A4. Note that the difference may not be visible on screen, but might show up when you are trying to print and A4 will mess up the final proceedings if left unchanged.
 
-**Note that current senior seminar templates use letter paper**, so you don't need to worry about it if you use our templates (as you should). 
+<div class="flash">
+<b>Note that current senior seminar templates use letter paper</b>, so you don't need to worry about it if you use our templates (as you should). 
+</div>
 
-#### <a name="a4change"></a>How do change my page size from A4 to Letter Paper?
-**Note that current senior seminar templates use letter paper**, so you don't need to worry about it if you use our templates (as you should). 
+### How do change my page size from A4 to Letter Paper?
 
 Using the templates from the senior seminar github fixes this issue Some LaTeX formatting programs allow you to set the paper size. For most of them, however, it's difficult to find and the setting may be overwritten later by A4 again. For the seminar proceedings use the sig-alternate.cls linked to the [resources page](seniorsemresources.md). It has a line
 
@@ -77,10 +73,10 @@ If you are using a different document class, such as article (this wouldn't be f
 
 after the document class.
 
-#### <a name="capital"></a>How do I preserve capitalization in titles in my bibliography?
+### How do I preserve capitalization in titles in my bibliography?
 If a paper title contains a word that needs to be capitalized, surround it by curly braces, e.g. `{CAPTCHA}` or `{Java}`.
 
-#### <a name="nav_icons"></a>How do I get rid of the navigation icons in Beamer?
+### How do I get rid of the navigation icons in Beamer?
 
 If you don't want those pesky presentation controls on your slides during your presentation, use this:
 

--- a/_resources/Senior seminar conferences.md
+++ b/_resources/Senior seminar conferences.md
@@ -1,10 +1,11 @@
 ---
-title: Senior Seminar conferences
+title: Senior Seminar Conferences
+order: 2
 ---
 
 # Senior Seminar conferences
 
-## About the conference.
+## About the conference
 
 Senior Seminar conference follows a standard CSci conference format. Each seminar participant presents their paper to the audience
 of peers, faculty, and guests (family, friends, and alums). Presentations summarize the papers, focusing on the key points, 

--- a/_resources/Senior seminar conferences.md
+++ b/_resources/Senior seminar conferences.md
@@ -1,10 +1,10 @@
 ---
-title: Senior seminar conferences
+title: Senior Seminar conferences
 ---
 
-# Senior seminar conferences
+# Senior Seminar conferences
 
-### About the conference.
+## About the conference.
 
 Senior Seminar conference follows a standard CSci conference format. Each seminar participant presents their paper to the audience
 of peers, faculty, and guests (family, friends, and alums). Presentations summarize the papers, focusing on the key points, 
@@ -29,6 +29,6 @@ restrictions.
 There is usually an informal gathering in the evening after the conference for students, their friends and family,
 and faculty to celebrate students' accomplishments and just to hang out.
 
-### Date and time
+## Date and time
 
 Senior Seminar conference is usually held on Saturday before the last week of the semester, starting early afternoon (about 1pm). 

--- a/_resources/Senior seminar conferences.md
+++ b/_resources/Senior seminar conferences.md
@@ -1,18 +1,18 @@
 ---
-title: Senior Seminar Conferences
+title: Senior seminar Conferences
 order: 2
 ---
 
-# Senior Seminar conferences
+# Senior seminar conferences
 
 ## About the conference
 
-Senior Seminar conference follows a standard CSci conference format. Each seminar participant presents their paper to the audience
+Senior seminar conference follows a standard CSci conference format. Each seminar participant presents their paper to the audience
 of peers, faculty, and guests (family, friends, and alums). Presentations summarize the papers, focusing on the key points, 
 and often omitting some level of details. Presentations are targeted towards CSci students who finished Data Structures. 
 Each presentation concludes by a brief question-and-answer period.
 
-Senior Seminar conference includes all student presentations as a one-day event (we have occasionally held it on Thursday/Friday,
+Senior seminar conference includes all student presentations as a one-day event (we have occasionally held it on Thursday/Friday,
 evenings, but we try to make it Saturday if at all possible). Talks are scheduled at half-an-hour intervals 
 (roughly 25 minutes per talk, including questions, and 5 minutes for people to stretch their legs and for the next speaker 
 to set up). We usually have half an hour break after the first two hours of talks. Refreshments and snacks are served.
@@ -27,9 +27,6 @@ Family and friends are welcome to attend the conference. The Csci discipline pro
 The building is handicap-accessible. Please let us know if you or your guests need any accommodations or have any dietary 
 restrictions.
 
-There is usually an informal gathering in the evening after the conference for students, their friends and family,
-and faculty to celebrate students' accomplishments and just to hang out.
-
 ## Date and time
 
-Senior Seminar conference is usually held on Saturday before the last week of the semester, starting early afternoon (about 1pm). 
+Senior seminar conference is usually held on a Saturday about three weeks before the end of the semester, starting early afternoon (about 1pm). 

--- a/_resources/Words of wisdom from past seniors.md
+++ b/_resources/Words of wisdom from past seniors.md
@@ -1,8 +1,11 @@
 ---
-title: Words of wisdom from past seniors
+title: Words of Wisdom
+order: 3
 ---
 
-# Suggestions for students who will be taking this course in the future 
+# Words of wisdom from past seniors
+
+### Suggestions for students who will be taking this course in the future 
 
 These are words of wisdom from those who took Senior Seminar and successfully passed, as the vast majority of Senior Seminar students do. Adapted from the end-of-semester questionnaire.
 

--- a/_resources/Words of wisdom from past seniors.md
+++ b/_resources/Words of wisdom from past seniors.md
@@ -6,7 +6,7 @@ title: Words of wisdom from past seniors
 
 These are words of wisdom from those who took Senior Seminar and successfully passed, as the vast majority of Senior Seminar students do. Adapted from the end-of-semester questionnaire.
 
-### Before the course (from your first year at UMM):
+## Before the course (from your first year at UMM):
 - Go to a senior seminar talk.
 - Find an area that interests you.
 - Have at least a general idea for a topic you may be interested in. Start looking at articles on that topic early and often, to be certain that you understand the material and that you are genuinely interested.
@@ -20,7 +20,7 @@ is would be useful).
 - Assume that it is a 3-credit course to get an accurate perspective of the workload (Elena's comment: this estimate varies, depending on the writing skills of the person, the topic difficulty, and the choice of sources).
 - Do not take more than 12 credits that semester to be able to put enough time and effort into other courses as well (Elena's comment: again, this is not necessary, but the workload is definitely a consideration). 
 
-### During the course:
+## During the course:
 
 - Don't get stressed out. The professors are there to help you.
 - Expect to put a lot of time into it.

--- a/_resources/cookieResources.md
+++ b/_resources/cookieResources.md
@@ -1,5 +1,6 @@
 ---
-title: Cookie system
+title: Cookie System
+order: 4
 ---
 
 # Senior seminar cookie system &#x1F36A;

--- a/_resources/seniorsemresources.md
+++ b/_resources/seniorsemresources.md
@@ -4,16 +4,12 @@ order: 1
 ---
 
 # Senior Seminar Resources
+{:.no_toc}
 
-- [Finding research papers](#finding-research-papers)
-- [Sample annotated bibliography](#sample-annotated-bibliography)
-- [Writing](#writing)
-- [LaTeX and formatting](#latex-and-formatting)
-- [ACM Computing Categories and General Terms](#acm-computing-categories-and-general-terms)
-- [Creative Commons licensing](#creative-commons-licensing)
-- [Sample beamer slides](#sample-beamer-slides)
+* Do not remove this line (it will not be displayed)
+{:toc}
 
-### Finding research papers
+## Finding research papers
 
 People find most of their resources from these sources, both available through Briggs Library:
 
@@ -45,21 +41,21 @@ People should feel free to help extend this. Other sources? What sources of pape
 
 [Meet Science: What is "peer review"?](http://boingboing.net/2011/04/22/meet-science-what-is.html)is a nice piece on what peer review is (and isn't).
 
-### Sample annotated bibliography
+## Sample annotated bibliography
 
 You can keep your annotated bibliography in a notebook or a text file on your computer,
 or you can use things like web-based bookmarking tools. 
 [This example shows](http://del.icio.us/bvisto) how a student used a bookmarking site to store and annotate his bibliography entries.
 
-### Writing
+## Writing
 
 ["How to get your article rejected" by Martin Hagger](https://www.chapman.edu/wilkinson/_files/crassh/how%20to%20get%20your%20article%20rejected.pdf) is a nice article humorously outlining a number of common
 (but often fatal) problems in writing up research papers.
 
-### LaTeX and formatting
+## LaTeX and formatting
 
 We use a slightly modified version of the ACM sig-alternate document class for our proceedings formatting.
-You can [get this from Github ](https://github.com/UMM-CSci/Senior_seminar_templates) along with example files/projects that illustrate the creation of annotated bibliographies
+You can [get this from Github](https://github.com/UMM-CSci/Senior_seminar_templates) along with example files/projects that illustrate the creation of annotated bibliographies
 and the creation of senior seminar papers for the proceedings. We'd recommend simply [forking that project](https://github.com/UMM-CSci/Senior_seminar_templates/fork) as that will give you 
 copies of all those files, a nice version control system for managing changes to your senior seminar work, 
 the ability to pull down changes we make to the master project, and the ability to issue pull requests on fixes or changes you
@@ -75,18 +71,13 @@ LaTeX resources:
 - [Mangling image from pdfs](mangling-image-from-pdfs.pdf) 
 - [Our own LaTeXFormattingFAQ](LatexformatingFAQ.md)
 
-### ACM Computing Categories and General Terms
+## ACM Computing Categories and General Terms
 
 - [The ACM Computing Classification System](http://www.acm.org/about/class/ccs98-html)
 - General terms must be a subset of the 16 terms [listed here](http://www.acm.org/about/class/1998/). 
 
-### Creative Commons licensing
-
-   [ Creative Common Licenses](Common Licences.md)
-        How to choose one, how to add it to your paper (including LaTeX). 
-
-### Sample beamer slides
+## Sample beamer slides
 
 [MarthasPresentation.pdf](marthaspresentation.pdf): A presentation generated in LaTeX package beamer 
 
-[MarthasPresentation.tex](marthaspresentation.pdf): The .tex source for Martha's presentation 
+[MarthasPresentation.tex](marthaspresentation.tex): The .tex source for Martha's presentation 

--- a/_resources/seniorsemresources.md
+++ b/_resources/seniorsemresources.md
@@ -1,6 +1,6 @@
 ---
 title: Senior Seminar Resources
-order: 1
+order: 8
 ---
 
 # Senior Seminar Resources

--- a/resources.md
+++ b/resources.md
@@ -6,6 +6,14 @@ permalink: /resources/
 match_collection: resources
 ---
 
-Public materials for senior seminar, including assignments, past papers/slides, templates, etc. 
+# Resources
 
-Go to [Senior_seminar_templates](https://github.com/UMM-CSci/Senior_seminar_templates) to fork the paper and talk templates.
+
+Resources for Senior Seminar:
+
+<ul>
+{% assign sorted_res = site.resources | sort:"order" %}
+{% for res in sorted_res %}
+<li><a href="{{res.url | relative_url}}">{{res.excerpt | strip_html }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
- Add an automatic table of contents for various pages so it does not need to be manually updated when the document is changed.
- Turn on relative links so you can link directly to `.md` files and it will be converted to a link to the actual html file.
- Update the main Resources page to list all the pages
  - I think this page still needs more information, but at least it doesn't look so blank now.
- Set a specific order for the Resource pages
  - Previously only the "Senior Seminar Resources" and "Course Description" pages were locked into their order and the rest would change every build.
  - I made this order loosely based on the existing README in the repo and what I thought works, if you have any suggestions for how to order the pages better, please mention it.
- Fix various errors in resource pages like bad links.
- Change the headers in many pages to have a better hierarchy and look better.

You can view what these changes look like on my fork here: https://floogulinc.com/senior-seminar/resources/.