### PR TITLE
Disable turbolinks on schedule for printing

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -11,9 +11,9 @@ layout: compress
     {% include header.html %}
 
     {{ content }}
-    
+
     <br>
 
-<script async src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.0.3/turbolinks.js" integrity="sha256-iRVODWVEZe2jDvJZwC7qI/Xx40YHzWS2bOX1z53lqC8=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/_resources/about.md
+++ b/_resources/about.md
@@ -13,7 +13,7 @@ This site uses [Jekyll](https://jekyllrb.com/) and is hosted on [GitHub Pages](h
 
 These are some extra pages not in the main navigation:
 
-- [Current schedule for printing]({{site.baseurl}}/current-schedule)
+- <a data-turbolinks="false" href="{{site.baseurl}}/current-schedule">Current schedule for printing</a>
 
 ## Contributing
 


### PR DESCRIPTION
It causes issues with navigation and styling when enabled for this page.

This PR also updates turbolinks to 5.2.0