### PR TITLE
Also show slides column if there are only gold stars in it

### DIFF
--- a/_layouts/seminar.html
+++ b/_layouts/seminar.html
@@ -75,7 +75,7 @@ layout: default
 
 {% assign show_slides = false %}
 {% for paper in page.papers %}
-{% if paper.slides or paper.slidesurl %}
+{% if paper.slides or paper.slidesurl or paper.distinctionslides %}
 {% assign show_slides = true %}
 {% break %}
 {% endif %}


### PR DESCRIPTION
Now the slides column will show up if distinctions have been added for slides without the slides themselves. 

Example: 
![image](https://user-images.githubusercontent.com/1300395/97791756-d1e50b00-1ba3-11eb-9464-3da1d8abde43.png)
