### PR TITLE
Hyphenation fix in Joe Walbran's paper title

### DIFF
--- a/_seminars/fall2021/index.md
+++ b/_seminars/fall2021/index.md
@@ -49,7 +49,7 @@ papers:
     time: 2021-11-13 11:30 AM
     room: Sci 3650
 
-  - title: Using Temporal Session Types to Analyze Time-Complexities of Concurrent Programs
+  - title: Using Temporal Session Types to Analyze Time Complexities of Concurrent Programs
     author: Joseph Moonan Walbran
     time: 2021-11-13 12:00 PM
     room: Sci 3650


### PR DESCRIPTION
Excuse me, this was my fault—I decided I didn't like how the title of my paper was hyphenated.

(I wrote "time-complexities" but now would prefer "time complexities".)